### PR TITLE
Add AGENTS.md for cloud agent development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,51 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Project overview
+
+MLB Elo Advantage is a pure Python data pipeline that scrapes MLB game results and betting odds, computes Elo ratings, and generates daily predictions. There is no database, no frontend, and no Docker. See `README.md` for full details.
+
+### Running the application
+
+Activate the virtual environment, then run the main pipeline:
+
+```bash
+source .venv/bin/activate
+python predictions.py
+```
+
+This scrapes Baseball Reference + ScoresAndOdds, runs the Elo engine on historical data, and outputs:
+- CSV: `OUTPUTS/Game Predictions Based on Ratings through YYYY-MM-DD.csv`
+- Markdown: `docs/index.md`
+- Data: `DATA/game_log_YYYY-MM-DD.csv`
+
+The full pipeline takes ~10 minutes due to network scraping + Monte Carlo season simulations (~12k–50k iterations).
+
+### Running without network (fast, offline)
+
+To run just the Elo simulation on existing data (no scraping, ~1 second):
+
+```bash
+source .venv/bin/activate
+python elo.py
+```
+
+### Linting and testing
+
+This project has no formal linting configuration or test suite. You can check for syntax errors with:
+
+```bash
+source .venv/bin/activate
+python -m py_compile predictions.py
+python -m py_compile elo.py
+python -m py_compile scraper.py
+python -m py_compile utils.py
+python -m py_compile season_predictions.py
+```
+
+### Known caveats
+
+- **Plotly browser output**: `utils.table_output()` tries to open Plotly tables in a browser. In headless environments this produces harmless dbus/GPU errors in stderr but does not affect pipeline correctness (caught by try/except).
+- **Scraping latency**: The odds scraper calls ScoresAndOdds for each date individually; during a long catchup (e.g. after multi-day gap) this can be slow.
+- **DATA directory**: The pipeline expects at least one `DATA/game_log_*.csv` file to exist as the baseline. The repo ships with these files already.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with cloud-specific development instructions for future Cursor Cloud agents working on this repository.

## What's included

- Project overview and architecture description
- Instructions for running the full pipeline (`python predictions.py`) and offline Elo simulation (`python elo.py`)
- Syntax-check commands (no formal linting/testing configured in repo)
- Known caveats about Plotly browser output in headless environments, scraping latency, and DATA directory requirements

## Environment verification

The development environment was verified end-to-end:
- Python 3.12 virtual environment with all dependencies from `requirements.txt`
- Full pipeline executed successfully: scraped Baseball Reference + ScoresAndOdds, ran Elo engine, generated 15 game predictions for 2026-05-16
- All 8 Python source files compile without syntax errors

[pipeline_verification.log](https://cursor.com/agents/bc-c5f6032c-d4a7-4db5-9465-fa63341401ae/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpipeline_verification.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c5f6032c-d4a7-4db5-9465-fa63341401ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5f6032c-d4a7-4db5-9465-fa63341401ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

